### PR TITLE
Add autocomplete to the run_modules

### DIFF
--- a/truckdevil/truckdevil.py
+++ b/truckdevil/truckdevil.py
@@ -91,7 +91,16 @@ class FrameworkCommands(cmd.Cmd):
             mod.main_mod(argv[1:], self.device)
         else:
             print("module not found, run 'list_modules'")
-
+            
+    def complete_run_module(self, text, line, begidx, endidx):
+        if not text:
+            completions = self.module_names[:]
+        else:
+            completions = [ f
+                            for f in self.module_names
+                            if f.startswith(text)
+                            ]
+        return completions
 
 if __name__ == "__main__":
     fc = FrameworkCommands()


### PR DESCRIPTION
This will allow you to autocomplete the module arguments in the run_module section. Will autocomplete the entered text otherwise the complete list of modules is returned.

Usage:
```
run_module <tab>
ecu_discovery  j1939_fuzzer   read_messages  send_messages  

run_module r<tab>
run_module read_messages

r<tab> r<tab>
run_module read_messages
```