### PR TITLE
Do not crash when can id cannot be parsed

### DIFF
--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -152,6 +152,9 @@ class Device:
                         sleeptime = 0.001
                     else:
                         sleeptime = sleeptime * 10
-                    print(f'error: {e:s} backing off delay to {sleeptime:d}')
+                    print(f'error: {e} backing off delay to {sleeptime:d}')
+                except Exception as e:
+                    print(f'error: {e} aborting.')
+                    return
                 finally:
                     return

--- a/truckdevil/modules/send_messages.py
+++ b/truckdevil/modules/send_messages.py
@@ -38,7 +38,12 @@ class SendCommands(Command):
         if can_id.startswith("0x"):
             can_id = int(can_id, 16)
         else:
-            can_id = int(can_id)
+            try:
+                can_id = int(can_id)
+            except Exception as e:
+                print(f'Could not parse can id - error: {e}')
+                return
+
         data = argv[1]
 
         message = J1939Message(can_id, data)


### PR DESCRIPTION
Fix issue #12 by adding a try and catch to the can id parsing. Additionally add a general exception clause to send to ensure that sending data does not cause a crash.