### PR TITLE
Timestamps and Candumps

### DIFF
--- a/truckdevil/j1939/j1939.py
+++ b/truckdevil/j1939/j1939.py
@@ -174,7 +174,6 @@ class J1939Interface:
             if not verbose:
                 if not candump:
                     print(j1939_message)
-
                     # Write the J1939 message to the log file if enabled
                     if log_to_file:
                         try:
@@ -186,15 +185,15 @@ class J1939Interface:
                     if j1939_message.total_bytes < 9:
                         try:
                             # Get the candump representation of the J1939 message and print it
-                            print(self.get_candump(j1939_message))
+                            output = print(self.get_candump(j1939_message))
                         except Exception as e:
                             # Print the error if unable to decode the message
                             print(f'error decoding message: {e}')
-
+                        print(output)
                         if log_to_file:
                             try:
                                 # Write the candump representation of the J1939 message to the log file
-                                log_file.write(self.get_candump(j1939_message) + '\n')
+                                log_file.write(output + '\n')
                             except Exception as e:
                                 # Print the error if unable to write to the log file
                                 print(f'error writing to log file: {e}')
@@ -204,8 +203,7 @@ class J1939Interface:
                     output = self.get_decoded_message(j1939_message)
                 except Exception as e:
                     # Print the error if unable to decode the message
-                    output = f'error decoding message: {e}'
-
+                    print(f'error decoding message: {e}')
                 print(output)
                 if log_to_file:
                     try:
@@ -214,7 +212,6 @@ class J1939Interface:
                     except Exception as e:
                         # Print the error if unable to write to the log file
                         print(f'error writing to log file: {e}')
-
             messages_printed = messages_printed + 1
         # Close the log file before exiting
         if log_to_file:

--- a/truckdevil/j1939/j1939.py
+++ b/truckdevil/j1939/j1939.py
@@ -422,7 +422,7 @@ class J1939Interface:
                 return None  # timeout occurred
             data = ''.join('{:02x}'.format(x) for x in can_msg.data)
             j1939_message = J1939Message(can_msg.arbitration_id, data)
-            j1939_message.timestamp = time.time()
+            j1939_message.timestamp = can_msg.timestamp 
 
             # Multipacket message received, broadcasted or peer-to-peer request to send
             if j1939_message.pdu_format == 0xec and (j1939_message.data[0:2] == "20" or j1939_message.data[0:2] == "10"):
@@ -1425,9 +1425,14 @@ class J1939Message:
                                                                                 self.total_bytes, self.data.upper())
 
         """
-        return "({:6f}) {:08X}    {:02X} {:04X} {:02X} --> {:02X} [{:04d}] {:<}".format(self.timestamp, self.can_id, self.priority, self.pgn,
-                                                                                self.src_addr, self.dst_addr,
-                                                                                self.total_bytes, self.data.upper())
+        return "({:6f}) {:08X}    {:02X} {:04X} {:02X} --> {:02X} [{:04d}] {:<}".format(self.timestamp, 
+                                                                                     self.can_id, 
+                                                                                     self.priority, 
+                                                                                     self.pgn,
+                                                                                     self.src_addr, 
+                                                                                     self.dst_addr,
+                                                                                     self.total_bytes, 
+                                                                                     self.data.upper())
 
         # return hex(self.can_id) + "  %02X %04X %02X --> %02X [%d]  %s" % (self.priority, self.pgn,
         #                                                                  self.src_addr, self.dst_addr,

--- a/truckdevil/j1939/j1939.py
+++ b/truckdevil/j1939/j1939.py
@@ -174,24 +174,46 @@ class J1939Interface:
             if not verbose:
                 if not candump:
                     print(j1939_message)
+
+                    # Write the J1939 message to the log file if enabled
                     if log_to_file:
-                        log_file.write(str(j1939_message) + '\n')
+                        try:
+                            log_file.write(str(j1939_message) + '\n')
+                        except Exception as e:
+                            # Print the error if unable to write to the log file
+                            print(f'error writing to log file: {e}')
                 else:
-                    if j1939_message.total_bytes < 9: 
-                        print(self.get_candump(j1939_message))
+                    if j1939_message.total_bytes < 9:
+                        try:
+                            # Get the candump representation of the J1939 message and print it
+                            print(self.get_candump(j1939_message))
+                        except Exception as e:
+                            # Print the error if unable to decode the message
+                            print(f'error decoding message: {e}')
+
                         if log_to_file:
-                            log_file.write(self.get_candump(j1939_message) + '\n')
+                            try:
+                                # Write the candump representation of the J1939 message to the log file
+                                log_file.write(self.get_candump(j1939_message) + '\n')
+                            except Exception as e:
+                                # Print the error if unable to write to the log file
+                                print(f'error writing to log file: {e}')
             else:
                 try:
-                    print(self.get_decoded_message(j1939_message))
+                    # Get the decoded message and print it
+                    output = self.get_decoded_message(j1939_message)
                 except Exception as e:
-                    print(f'error decoding message: {e}')
+                    # Print the error if unable to decode the message
+                    output = f'error decoding message: {e}'
 
+                print(output)
                 if log_to_file:
                     try:
-                        log_file.write(self.get_decoded_message(j1939_message) + '\n')
+                        # Write the decoded message to the log file
+                        log_file.write(output + '\n')
                     except Exception as e:
-                        log_file.write(f'error decoding message: {e}')
+                        # Print the error if unable to write to the log file
+                        print(f'error writing to log file: {e}')
 
             messages_printed = messages_printed + 1
         # Close the log file before exiting

--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -132,8 +132,6 @@ class Device:
                     start_reading = False
         else:
             msg = self._can_bus.recv(timeout=timeout)
-            # Phil Debugging
-            print("({:.6f})".format(msg.timestamp),end=' ')
             return msg
 
     def send(self, msg: Message):

--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -132,6 +132,8 @@ class Device:
                     start_reading = False
         else:
             msg = self._can_bus.recv(timeout=timeout)
+            # Phil Debugging
+            print("({:.6f})".format(msg.timestamp),end=' ')
             return msg
 
     def send(self, msg: Message):

--- a/truckdevil/modules/read_messages.py
+++ b/truckdevil/modules/read_messages.py
@@ -27,6 +27,9 @@ class Reader:
             Setting("verbose", False).add_constraint("boolean", lambda x: type(x) is bool)
                 .add_description("Display the messages in decoded form, if applicable."),
 
+            Setting("candump", False).add_constraint("boolean", lambda x: type(x) is bool)
+                .add_description("Display the messages in candump format"),
+
             Setting("filter_can_id", [0]).add_constraint("list_of_ints", lambda x: all(isinstance(i, int) for i in x))
                 .add_description("Only read messages containing one of these CAN IDs."),
 
@@ -188,7 +191,8 @@ class ReadCommands(Command):
             file_name = self.reader.sm.log_name
         try:
             self.devil.print_messages(self.reader.sm.abstract_TPM, read_time, num_messages,
-                                      self.reader.sm.verbose, self.reader.sm.log_to_file, file_name, **filters)
+                                      self.reader.sm.verbose, self.reader.sm.log_to_file, file_name, 
+                                      self.reader.sm.candump, **filters)
         except KeyboardInterrupt:
             return
         except FileExistsError:


### PR DESCRIPTION
Fixes issue #19 

Updates
* Extends J1939 message to add timestamp. 
* On constructed multipacket and ISO-TP messages the time of the whole message reconstruction is used
* Added candump log format configuration option (*note* candump format does not reconstruct ISOTP or multipacket messages)