### PR TITLE
TCP SocketCAN <-> M2 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Additionally, an OBD-II to J1939 deutsch 9 pin adapter or splitter could be util
 
 Additional software is required to flash the m2_sketch firmware to the M2, if used (see Installation).
 
+If you would like to read J1939 messages remotely, a TCP socket server can be set up to bridge M2 encoded messages to a remote client also running TruckDevil. (see [remote](#remote-socket-server))
+
 ## Installation
 ```
 > git clone https://github.com/LittleBlondeDevil/TruckDevil.git
@@ -130,3 +132,27 @@ def main_mod(argv, device)
 
 Python docs are available in the j1939.py file. Existing modules provide example usage.
 
+### Remote Socket Server
+
+
+An example TCP socket server and systemd service for Linux based machines is included in the [tcp](tcp) folder. This server then encodes SocketCAN to M2 CAN messages and sends them to the TruckDevil client.
+```
+python3 .\truckdevil-tcp -h
+usage: truckdevil-tcp [-h] [-v] bind_ip tcp_port
+
+Bridge a SocketCAN interface <-> M2-over-TCP.
+
+positional arguments:
+  bind_ip        IP address to bind the server socket
+  tcp_port       TCP port to listen on
+
+options:
+  -h, --help     show this help message and exit
+  -v, --verbose  Increase verbosity (-v for INFO, -vv for DEBUG)
+```
+
+To connect to the server, add it as a device. For example:
+```
+(truckdevil) add_device m2:192.168.7.2 can0 500000 1234
+```
+You can then read and write messages to the server as if it were a local device.

--- a/tcp/truckdevil-tcp
+++ b/tcp/truckdevil-tcp
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import socket
+import select
+import subprocess
+from typing import Optional
+import can
+
+logger = logging.getLogger(__name__)
+
+def can_setup(iface: str, baud: int) -> bool:
+    """Bring down 'iface', then bring it up at 'baud' (or 250k if baud=0). This needs root privs."""
+    cmd_down = ["ip", "link", "set", iface, "down"]
+    if subprocess.call(cmd_down) != 0:
+        logger.error("Could not bring down %s.", iface)
+        return False
+
+    if baud == 0:
+        baud = 250000  # default fallback
+
+    cmd_up = ["ip", "link", "set", iface, "up", "type", "can", "bitrate", str(baud)]
+    if subprocess.call(cmd_up) != 0:
+        logger.error("Could not bring up %s at baud %d", iface, baud)
+        return False
+
+    logger.info("Interface '%s' is up at %d bps.", iface, baud)
+    return True
+
+def encode(msg: can.Message) -> str:
+    """
+    Encode a python-can Message into M2 format: $<ID><DLC><DATA>*
+    - 8 hex digits if extended; up to 3 if standard.
+    """
+    can_id = msg.arbitration_id
+    is_extended = msg.is_extended_id
+
+    # Start delimiter
+    out = "$"
+    if is_extended:
+        out += f"{can_id:08X}"      # 8 hex for extended
+    else:
+        out += f"{can_id & 0x7FF:03X}"  # up to 3 hex for standard
+
+    # DLC => 2 hex
+    out += f"{msg.dlc:02X}"
+
+    # Data => DLC * 2 hex
+    out += msg.data.hex().upper()
+
+    return out + "*"
+
+def decode(m2str: str) -> Optional[can.Message]:
+    """
+    Decode an M2 string (excluding '$' and '*') into a python-can Message.
+    If >=10 hex => extended (8 hex ID), else standard (3 hex ID).
+    Returns None on parse error.
+    """
+    length = len(m2str)
+    if length < 5:  # minimum = 3 (ID) + 2 (DLC) = 5
+        return None
+
+    is_extended = (length >= 10)
+    id_len = 8 if is_extended else 3
+
+    if id_len > length:
+        return None
+
+    # ID
+    try:
+        can_id = int(m2str[:id_len], 16)
+    except ValueError:
+        return None
+
+    if not is_extended and can_id > 0x7FF:
+        return None  # invalid standard ID
+
+    # DLC
+    dlc_str = m2str[id_len:id_len+2]
+    try:
+        dlc = int(dlc_str, 16)
+    except ValueError:
+        return None
+    if dlc < 0 or dlc > 8:
+        return None
+
+    # DATA
+    data_hex = m2str[id_len+2:]
+    if len(data_hex) != dlc * 2:
+        return None
+    try:
+        data = bytes.fromhex(data_hex)
+    except ValueError:
+        return None
+
+    return can.Message(arbitration_id=can_id,
+                       is_extended_id=is_extended,
+                       dlc=dlc,
+                       data=data,
+                       is_rx=False)
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Bridge a SocketCAN interface <-> M2-over-TCP.")
+    parser.add_argument("bind_ip", help="IP address to bind the server socket")
+    parser.add_argument("tcp_port", type=int, help="TCP port to listen on")
+    parser.add_argument("-v", "--verbose", action="count", default=0,
+                        help="Increase verbosity (-v for INFO, -vv for DEBUG)")
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    log_level = logging.WARNING
+    if args.verbose == 1:
+        log_level = logging.INFO
+    elif args.verbose >= 2:
+        log_level = logging.DEBUG
+    logging.basicConfig(level=log_level,
+                        format="%(levelname)s: %(message)s")
+
+    srv_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv_sock.bind((args.bind_ip, args.tcp_port))
+    srv_sock.listen(1)
+
+    logger.info("Listening on %s:%d...", args.bind_ip, args.tcp_port)
+
+    # only one client per process
+    cli_sock, cli_addr = srv_sock.accept()
+    logger.info("Client connected from %s:%d", cli_addr[0], cli_addr[1])
+    srv_sock.close()
+
+    # #<7-digit-baud><4-char-iface>
+    #   (Blocking approach for simplicity)
+    def recv_exact(nbytes: int) -> bytes:
+        buf = bytearray()
+        while len(buf) < nbytes:
+            chunk = cli_sock.recv(nbytes - len(buf))
+            if not chunk:
+                return b''
+            buf.extend(chunk)
+        return bytes(buf)
+
+    # wait for '#'
+    while True:
+        c = cli_sock.recv(1)
+        if not c:
+            logger.error("Client disconnected before init.")
+            cli_sock.close()
+            return
+        if c == b'#':
+            break
+
+    init_data = recv_exact(11)
+    if len(init_data) < 11:
+        logger.error("Client disconnected during initialization.")
+        cli_sock.close()
+        return
+
+    baud_str = init_data[:7].decode('ascii', errors='replace')
+    iface_str = init_data[7:].decode('ascii', errors='replace')
+
+    try:
+        can_baud = int(baud_str)
+    except ValueError:
+        can_baud = 0
+
+    logger.info("Init => Baud=%d, Iface=%s", can_baud, iface_str)
+
+    # flush any leftover data and set non-blocking
+    leftover_data = b''
+    cli_sock.setblocking(False)
+    try:
+        while True:
+            chunk = cli_sock.recv(4096)
+            if not chunk:
+                break
+            leftover_data += chunk
+    except BlockingIOError:
+        pass
+
+    # bring up the CAN interface
+    if not can_setup(iface_str, can_baud):
+        cli_sock.close()
+        return
+
+    # python-can setup
+    try:
+        bus = can.interface.Bus(channel=iface_str, bustype="socketcan")
+    except OSError as e:
+        logger.error("Could not open CAN interface %s: %s", iface_str, e)
+        cli_sock.close()
+        return
+
+    logger.info("Now bridging M2 <-> CAN on %s (baud=%d)", iface_str, can_baud)
+    tcp_inbuf = leftover_data.decode('utf-8', errors='replace')
+
+    while True:
+        msg = bus.recv(timeout=0.0)
+        if msg:
+            out_str = encode(msg)
+            try:
+                cli_sock.sendall(out_str.encode('utf-8', errors='replace'))
+            except (BlockingIOError, BrokenPipeError):
+                logger.info("Client disconnected.")
+                break
+
+        # select for non-blocking recv
+        rlist, _, _ = select.select([cli_sock], [], [], 0.01)
+        if cli_sock in rlist:
+            try:
+                chunk = cli_sock.recv(4096)
+                if not chunk:
+                    logger.info("Client disconnected.")
+                    break
+                tcp_inbuf += chunk.decode('utf-8', errors='replace')
+            except BlockingIOError:
+                pass
+
+        # parse $...* from tcp_inbuf
+        while True:
+            start_pos = tcp_inbuf.find('$')
+            if start_pos < 0:
+                break
+            end_pos = tcp_inbuf.find('*', start_pos)
+            if end_pos < 0:
+                # incomplete message
+                break
+
+            frame_str = tcp_inbuf[start_pos+1:end_pos]
+            # remove that chunk from tcp_inbuf
+            tcp_inbuf = tcp_inbuf[:start_pos] + tcp_inbuf[end_pos+1:]
+
+            decoded_msg = decode(frame_str)
+            if decoded_msg:
+                try:
+                    bus.send(decoded_msg)
+                except can.CanError as e:
+                    logger.error("CAN send error: %s", e)
+            else:
+                logger.debug("Invalid M2 frame ignored: %s", frame_str)
+
+    cli_sock.close()
+    logger.info("Bridge shutdown.")
+
+if __name__ == "__main__":
+    main()

--- a/tcp/truckdevil-tcp.service
+++ b/tcp/truckdevil-tcp.service
@@ -1,0 +1,13 @@
+# change the ip and port if needed
+[Unit]
+Description=TCP M2 Encoder Router
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/truckdevil-tcp -v 0.0.0.0 1234
+Restart=on-failure
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -3,144 +3,122 @@ from can import interface, Message
 import serial
 import time
 import threading
+import socket
 
 
 class Device:
-    def __init__(self, device_type="m2", serial_port=None, channel='can0', can_baud=0):
+    def __init__(self, device_type="m2", tcp_ip=None, port=None, channel='can0', can_baud=0):
         """
         Defines a new hardware device
 
         :param device_type: either "m2" or "socketcan" (Default value = "m2").
-        :param serial_port: serial port that the M2 is connected to, if used. For example: COM7 or /dev/ttyX."
-        :param channel: CAN channel to send/receive on. For example: can0, can1, or vcan0. (Default value = 'can0')
-        :param can_baud: baudrate on the CAN bus. Most common are 250000 and 500000. Use 0 for autobaud detection. (Default value = 0)
+        :param tcp_ip: IP address of the M2 if using TCP, e.g. 192.168.7.2.
+        :param port: serial port that the M2 is connected to, if used. For example: COM7 or /dev/ttyX. 
+                     If using M2 encoder over TCP, this is the TCP port. For example: 1234.
+        :param channel: CAN channel to send/receive on. For example: can0, can1, or vcan0. (Default value = 'can0').
+        :param can_baud: baudrate on the CAN bus. Most common are 250000 and 500000. Use 0 for autobaud detection on the M2 only. (Default value = 0)
         """
-        self._device_type = device_type
-        self._serial_port = serial_port
+        self._device_type = device_type.lower()
+        self._tcp_ip = tcp_ip
+        self._port = port
         self._channel = channel
-        self._can_baud = can_baud
+        self._can_baud = int(can_baud)
+
         self.device_lock = threading.RLock()
         self._acknowledged_flush = True
-        if device_type.lower() == "m2":
-            if serial_port is None:
-                raise ValueError("If using M2, serial port must be specified")
-            self._m2 = serial.Serial(
-                port=serial_port, baudrate=115200,
-                dsrdtr=True
-            )
-            self._m2.setDTR(True)
-            # self._lockM2 = threading.RLock()
-            # Ensure that can_baud is filled to 7 digits
-            self.init_m2(self._can_baud, self._channel)
-            self._m2used = True
-        else:
-            # TODO: test other devices
-            self._can_bus = interface.Bus(bustype=device_type, channel=channel, bitrate=can_baud)
-            self._m2used = False
+        self._m2used  = False
+        self._tcpused = False
+        self._m2 = None
+        self._socket = None
+        self._can_bus = None
 
+        if self._device_type == "m2": # m2
+            if self._tcp_ip is not None: # over tcp
+                self._tcpused = True
+                if self._port is None:
+                    raise ValueError("If using M2 over TCP, port must be specified")
+                self._port = int(self._port)
+                self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                self._socket.connect((self._tcp_ip, self._port))
+                self.init_m2(self._can_baud, self._channel)
+
+            else: # over serial 
+                if self._port is None:
+                    raise ValueError("If using M2, serial port must be specified")
+                self._m2 = serial.Serial(
+                    port=self._port, baudrate=115200,
+                    dsrdtr=True
+                )
+                self._m2.setDTR(True)
+                # self._lockM2 = threading.RLock()
+                # Ensure that can_baud is filled to 7 digits
+                self.init_m2(self._can_baud, self._channel)
+                self._m2used = True
+
+        else: # python-can
+            # TODO: test other devices
+            self._can_bus = interface.Bus(bustype=self._device_type, channel=self._channel, bitrate=self._can_baud)
+            self._m2used = False
     def __str__(self):
-        device_str = "\n***** CAN Device Info *****" + "\nDevice Type: " + self._device_type
-        if self._serial_port is not None:
-            device_str += "\nSerial Port: " + self._serial_port
-        device_str += "\nCAN Channel: " + self._channel + "\nBaud Rate: " + str(self._can_baud)
+        device_str = "\n***** CAN Device Info *****"
+        device_str += "\nDevice Type: " + str(self._device_type) + (" encoder" if self._tcp_ip else "")
+        if self._tcp_ip:
+            device_str += "\nTCP IP: " + str(self._tcp_ip)
+        if self._port:
+            device_str += "\nPort: " + str(self._port)
+        device_str += "\nCAN Channel: " + str(self._channel)
+        device_str += "\nBaud Rate: " + str(self._can_baud)
         return device_str
 
     @property
     def m2_used(self):
         return self._m2used
 
-    @property
-    def m2(self):
-        return self._m2
-
-    @property
-    def can_bus(self):
-        return self._can_bus
-
     def init_m2(self, can_baud: int, channel: str):
         """
         Send command to M2 to set the CAN baud rate and channel that will be used
-
-        :param can_baud: baudrate on the CAN bus. Most common are 250000 and 500000. Use 0 for autobaud detection.
-        :param channel: CAN channel to send/receive on. For example: can0, can1, or vcan0.
         """
         baud_to_send = '#' + str(can_baud).zfill(7)
-        if channel == "can0" or channel == "can1":
-            baud_to_send += channel
+        if self._channel == "can0" or self._channel == "can1":
+            baud_to_send += self._channel
         else:
             baud_to_send += "can0"
-        self.m2.write(baud_to_send.encode('utf-8'))
+            self._channel = "can0"
+        self._write_raw(baud_to_send.encode('utf-8'))
 
     def flush_m2(self):
+        """
+        Clears out any partial frames waiting in the buffer.
+        """
         self._acknowledged_flush = False
-        self.m2.reset_input_buffer()
+        if self._m2used:
+            self._m2.reset_input_buffer()
+        elif self._tcpused:
+            pass
 
-    def read(self, timeout=None) -> Message:
+    def read(self, timeout=0.1) -> Message:
         """
-        Reads one message from device, creates python-can Message, and returns it
-        If optional timeout occurs, return None
+        Reads one message from device, creates python-can Message, and returns it.
+        If optional timeout occurs, return None.
         """
-        if self.m2_used:
-            response = ""
-            start_reading = False
-            char = ''
-            self._m2.timeout = timeout
-            while True:
-                if not self._acknowledged_flush:
-                    response = ""
-                    start_reading = False
-                    self._acknowledged_flush = True
-                # Receive next character from M2
-                try:
-                    char = self._m2.read().decode("utf-8")
-                except UnicodeDecodeError:
-                    # Something went wrong
-                    # TODO: figure out why this error is occasionally raised - is the M2 sending an error frame??
-                    continue
-                if len(char) == 0:  # timeout occurred
-                    self._m2.timeout = None
-                    return None
-                # Denotes start of CAN message
-                if start_reading is False and char == '$':
-                    response = '$'
-                    start_reading = True
-                # Reading contents of CAN message, appending to response
-                elif start_reading is True and char != '*':
-                    response += char
-                # Denotes end of CAN message - return response
-                elif (start_reading is True and len(response) > 0 and
-                      response[0] == '$' and char == '*' and
-                      response.count('$') == 1):
-                    try:
-                        str_frame = response[1:]
-                        if len(str_frame) < 10:
-                            raise ValueError("str_frame too short, error occurred")
-                        can_id = int(str_frame[0:8], 16)
-                        dlc = int(str_frame[8:10], 16)
-                        # TODO: remove print, or add check to ensure data is not more than 8 bytes long bc some error
-                        #  occurred
-                        data = bytes.fromhex(str_frame[10:])
-                        return Message(arbitration_id=can_id, channel=self._channel, dlc=dlc, data=data,
-                                       is_extended_id=True, timestamp=time.time())
-                    except ValueError as e:
-                        print("error in creating Message in device read: {}".format(e))
-                        print("str_frame: {}".format(str_frame))
-                        continue
-                # If the serial buffer gets flushed during reading
-                elif response.count('$') > 1:
-                    response = ""
-                    start_reading = False
+        if self._m2used or self._tcpused:
+            return self._read_m2_common(timeout)
         else:
-            msg = self._can_bus.recv(timeout=timeout)
-            return msg
+            # For python-can
+            return self._can_bus.recv(timeout=timeout)
 
     def send(self, msg: Message):
-        if self.m2_used:
-            # convert from Message to $1CECFF000820120003FFCAFE00* format
+        """
+        Sends a python-can Message to the underlying device.
+        """
+        if self._m2used or self._tcpused:
+            # Convert from python-can Message to $1CECFF000820120003FFCAFE00* format
             can_id = hex(msg.arbitration_id)[2:].zfill(8)
             dlc = hex(msg.dlc)[2:].zfill(2)
             data = ''.join('{:02x}'.format(x) for x in msg.data)
-            self.m2.write("${}{}{}*".format(can_id, dlc, data).encode('utf-8'))
+            frame = "${}{}{}*".format(can_id, dlc, data)
+            self._write_raw(frame.encode('utf-8'))
         else:
             sleeptime = 0.0
             while True:
@@ -158,3 +136,86 @@ class Device:
                     return
                 finally:
                     return
+
+    ### internal helper methods ###            
+    def _write_raw(self, raw_bytes: bytes):
+        """ Helper that writes raw bytes either to serial or TCP socket. """
+        if self._m2used:
+            self._m2.write(raw_bytes)
+        elif self._tcpused:
+            self._socket.sendall(raw_bytes)
+
+    def _read_m2_common(self, timeout=0.1) -> Message:
+        """
+        Single method that reads data from either the serial port or the TCP socket,
+        using the same framing as the original M2 logic.
+        """
+        response = ""
+        start_reading = False
+
+        # set up a read timeout for whichever underlying I/O we have
+        if self._m2used:
+            self._m2.timeout = timeout
+        elif self._tcpused:
+            self._socket.settimeout(timeout)
+
+        while True:
+            if not self._acknowledged_flush:
+                response = ""
+                start_reading = False
+                self._acknowledged_flush = True
+            # Receive next character from M2
+            if self._m2used:
+                chunk = self._m2.read(1)  # 1 byte
+                if len(chunk) == 0:
+                    # timeout or EOF
+                    self._m2.timeout = None
+                    continue
+                char = chunk.decode("utf-8", errors="replace")
+
+            else:  # self._tcpused
+                try:
+                    chunk = self._socket.recv(1)
+                    if len(chunk) == 0:
+                        continue
+                    char = chunk.decode("utf-8", errors="replace")
+                except socket.timeout:
+                    continue
+
+            # Denotes start of CAN message
+            if not start_reading and char == '$':
+                response = '$'
+                start_reading = True
+            # Reading contents of CAN message
+            elif start_reading and char != '*':
+                response += char
+            # Denotes end of CAN message
+            elif start_reading and char == '*' and response.startswith('$'):
+                try:
+                    str_frame = response[1:]  # strip off leading $
+                    if len(str_frame) < 10:
+                        raise ValueError("str_frame too short")
+
+                    can_id = int(str_frame[0:8], 16)
+                    dlc = int(str_frame[8:10], 16)
+                    data_hex = str_frame[10:]
+                    # TODO: remove print, or add check to ensure data is not more than 8 bytes long bc some error
+                    #  occurred
+                    data = bytes.fromhex(data_hex)
+                    return Message(
+                        arbitration_id=can_id,
+                        channel=self._channel,
+                        dlc=dlc,
+                        data=data,
+                        is_extended_id=True,
+                        timestamp=time.time()
+                    )
+                except ValueError as e:
+                    print(f"error in creating Message in device read: {e}")
+                    print(f"str_frame: {response}")
+                    continue
+
+            # If the buffer gets flushed during reading
+            if response.count('$') > 1:
+                response = ""
+                start_reading = False

--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -53,13 +53,14 @@ class Device:
                 self._m2.setDTR(True)
                 # self._lockM2 = threading.RLock()
                 # Ensure that can_baud is filled to 7 digits
-                self.init_m2(self._can_baud, self._channel)
                 self._m2used = True
+                self.init_m2(self._can_baud, self._channel)
 
         else: # python-can
             # TODO: test other devices
             self._can_bus = interface.Bus(bustype=self._device_type, channel=self._channel, bitrate=self._can_baud)
             self._m2used = False
+
     def __str__(self):
         device_str = "\n***** CAN Device Info *****"
         device_str += "\nDevice Type: " + str(self._device_type) + (" encoder" if self._tcp_ip else "")


### PR DESCRIPTION
Should provide more options for users who would like to remotely decode J1939 frames. This version has only modified the device.py and truckdevil.py scripts, and added some example scripts utilized on the [UTHP](https://github.com/SystemsCyber/UTHP). 