### PR TITLE
Add --version flag and bump to v1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 import os
+import re
 
 
 def read(*paths):
@@ -8,9 +9,14 @@ def read(*paths):
         return f.read()
 
 
+def get_version():
+    init = read('truckdevil', '__init__.py')
+    return re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", init).group(1)
+
+
 setup(
     name='truckdevil',
-    version='1.0.0',
+    version=get_version(),
     description='J1939 testing framework',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",

--- a/tests/test_framework_cli.py
+++ b/tests/test_framework_cli.py
@@ -1,6 +1,7 @@
 """Tests for framework CLI (truckdevil.py) with virtual device."""
 import importlib.util
 import os
+import re
 import sys
 import uuid
 
@@ -31,6 +32,42 @@ def _load_framework_commands():
 @pytest.fixture
 def shared_channel():
     return f"cli-{uuid.uuid4().hex}"
+
+
+def _load_version():
+    """Load __version__ from truckdevil/__init__.py."""
+    spec = importlib.util.spec_from_file_location(
+        "truckdevil_init",
+        os.path.join(_TRUCKDEVIL_DIR, "__init__.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.__version__
+
+
+def test_version_format():
+    """__version__ exists and follows semver (MAJOR.MINOR.PATCH)."""
+    version = _load_version()
+    assert re.match(r"^\d+\.\d+\.\d+$", version), f"unexpected version format: {version}"
+
+
+def test_version_in_intro_banner(truckdevil_module_env):
+    """The intro banner contains the version string."""
+    FrameworkCommands = _load_framework_commands()
+    version = _load_version()
+    fc = FrameworkCommands()
+    assert version in fc.intro
+
+
+def test_version_flag(truckdevil_module_env):
+    """python truckdevil.py --version prints 'truckdevil <version>' and exits."""
+    import subprocess
+    result = subprocess.run(
+        [sys.executable, os.path.join(_TRUCKDEVIL_DIR, "truckdevil.py"), "--version"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    assert _load_version() in result.stdout
 
 
 def test_cli_add_device_list_device(truckdevil_module_env, shared_channel):

--- a/truckdevil/__init__.py
+++ b/truckdevil/__init__.py
@@ -1,1 +1,2 @@
 name = 'truckdevil'
+__version__ = '1.1.0'

--- a/truckdevil/truckdevil.py
+++ b/truckdevil/truckdevil.py
@@ -4,10 +4,11 @@ import sys
 from pkgutil import iter_modules
 
 from libs.device import Device
+from __init__ import __version__
 
 
 class FrameworkCommands(cmd.Cmd):
-    intro = "Welcome to the truckdevil framework. Type 'help or ?' for a list of commands."
+    intro = "Welcome to the truckdevil framework v{}. Type 'help or ?' for a list of commands.".format(__version__)
     prompt = '(truckdevil) '
 
     def __init__(self):
@@ -136,6 +137,10 @@ class FrameworkCommands(cmd.Cmd):
         return completions
 
 if __name__ == "__main__":
+    if "--version" in sys.argv or "-V" in sys.argv:
+        print("truckdevil {}".format(__version__))
+        sys.exit(0)
+
     fc = FrameworkCommands()
     if len(sys.argv) > 1:
         if sys.argv[1] == "add_device" and "run_module" in sys.argv:


### PR DESCRIPTION
- Add __version__ to truckdevil/__init__.py as single source of truth

- Support --version and -V flags in CLI to print version and exit

- Show version in the intro banner on startup

- Read version dynamically in setup.py instead of hardcoding

- Add tests for version format, banner, and --version flag

- Bump version to 1.1.0 to reflect the merged test suite

Made-with: Cursor