### PR TITLE
Fix send_messages crash on bad input data (closes #12)

### DIFF
--- a/tests/test_module_send_messages.py
+++ b/tests/test_module_send_messages.py
@@ -80,3 +80,75 @@ def test_send_messages_invalid_args_no_data(truckdevil_module_env, shared_channe
                 device.can_bus.shutdown()
             except Exception:
                 pass
+
+
+def test_send_messages_bad_hex_can_id(truckdevil_module_env, shared_channel):
+    """send 0xZZZZ AABB: prints error instead of crashing."""
+    from libs.device import Device
+    import modules.send_messages as send_messages
+
+    device = Device("virtual", None, shared_channel, 250000)
+    try:
+        buf = __import__("io").StringIO()
+        old = sys.stdout
+        try:
+            sys.stdout = buf
+            send_messages.main_mod(["send", "0xZZZZ", "AABB", "back"], device)
+        finally:
+            sys.stdout = old
+        out = buf.getvalue()
+        assert "could not parse can id" in out.lower()
+    finally:
+        if device.can_bus is not None:
+            try:
+                device.can_bus.shutdown()
+            except Exception:
+                pass
+
+
+def test_send_messages_bad_data_non_hex(truckdevil_module_env, shared_channel):
+    """send 0x18EA00FF XYZ123: prints error instead of crashing."""
+    from libs.device import Device
+    import modules.send_messages as send_messages
+
+    device = Device("virtual", None, shared_channel, 250000)
+    try:
+        buf = __import__("io").StringIO()
+        old = sys.stdout
+        try:
+            sys.stdout = buf
+            send_messages.main_mod(["send", "0x18EA00FF", "XYZ123", "back"], device)
+        finally:
+            sys.stdout = old
+        out = buf.getvalue()
+        assert "invalid message" in out.lower()
+    finally:
+        if device.can_bus is not None:
+            try:
+                device.can_bus.shutdown()
+            except Exception:
+                pass
+
+
+def test_send_messages_bad_data_odd_length(truckdevil_module_env, shared_channel):
+    """send 0x18EA00FF AAB: prints error for odd-length hex data."""
+    from libs.device import Device
+    import modules.send_messages as send_messages
+
+    device = Device("virtual", None, shared_channel, 250000)
+    try:
+        buf = __import__("io").StringIO()
+        old = sys.stdout
+        try:
+            sys.stdout = buf
+            send_messages.main_mod(["send", "0x18EA00FF", "AAB", "back"], device)
+        finally:
+            sys.stdout = old
+        out = buf.getvalue()
+        assert "invalid message" in out.lower()
+    finally:
+        if device.can_bus is not None:
+            try:
+                device.can_bus.shutdown()
+            except Exception:
+                pass

--- a/truckdevil/modules/send_messages.py
+++ b/truckdevil/modules/send_messages.py
@@ -35,18 +35,22 @@ class SendCommands(Command):
             print("arguments not found, see 'help send'")
             return
         can_id = argv[0]
-        if can_id.startswith("0x"):
-            can_id = int(can_id, 16)
-        else:
-            try:
+        try:
+            if can_id.startswith("0x") or can_id.startswith("0X"):
+                can_id = int(can_id, 16)
+            else:
                 can_id = int(can_id)
-            except Exception as e:
-                print(f'Could not parse can id - error: {e}')
-                return
+        except ValueError as e:
+            print(f'Could not parse can id - error: {e}')
+            return
 
         data = argv[1]
 
-        message = J1939Message(can_id, data)
+        try:
+            message = J1939Message(can_id, data)
+        except ValueError as e:
+            print(f'Invalid message - error: {e}')
+            return
         if len(argv) == 3:
             verbose = argv[2][1:].lower()
             if verbose == 'v':


### PR DESCRIPTION
Wrap CAN ID parsing and J1939Message construction in try/except so

invalid input prints a friendly error instead of crashing the REPL.

Add tests for bad hex CAN ID, non-hex data, and odd-length data.

Made-with: Cursor