### PR TITLE
Fix Device.send() retry loop never retrying

### DIFF
--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -147,14 +147,13 @@ class Device:
                 try:
                     self._can_bus.send(msg)
                     time.sleep(sleeptime)
+                    return
                 except can.CanOperationError as e:
                     if sleeptime == 0.0:
                         sleeptime = 0.001
                     else:
                         sleeptime = sleeptime * 10
-                    print(f'error: {e} backing off delay to {sleeptime:d}')
+                    print(f'error: {e} backing off delay to {sleeptime}')
                 except Exception as e:
                     print(f'error: {e} aborting.')
-                    return
-                finally:
                     return


### PR DESCRIPTION
## Summary
- The `finally: return` in `Device.send()` (non-M2 path) caused the `while True` loop to exit on every iteration, making the exponential backoff logic dead code.
- Moved `return` into the `try` block so it only exits after a successful send, allowing retries on `CanOperationError`.
- Fixed `{sleeptime:d}` format specifier to `{sleeptime}` since `sleeptime` is a float.

## Test plan
- [x] All 170 existing tests pass
- [x] No new test needed -- existing `test_device_virtual.py` covers send/receive; the retry path requires a real CAN bus under load to trigger `CanOperationError`