### PR TITLE
Fix two bugs in j1939_fuzzer

### DIFF
--- a/truckdevil/modules/j1939_fuzzer.py
+++ b/truckdevil/modules/j1939_fuzzer.py
@@ -361,7 +361,7 @@ class J1939Fuzzer:
 
         data = test_case_values.setdefault("data", None)
         if data is None:
-            if 2 < option < 0:
+            if not (0 <= option <= 2):
                 option = random.randint(0, 2)
             if option == 0:
                 data = ''
@@ -488,7 +488,7 @@ class J1939Fuzzer:
                     anomaly = True
                     any_anomalies = True
                     message = "new PGNs detected from target: " + str(
-                            set(self.baseline[src]['pgns'].keys()) - set(after_fuzz[src]['pgns']))
+                            set(after_fuzz[src]['pgns'].keys()) - set(self.baseline[src]['pgns']))
                 if anomaly:
                     print("\n    source: " + str(src))
                     print("        interval messages/second: " + str(curr_per_sec))


### PR DESCRIPTION
## Summary
- `generate()`: The condition `if 2 < option < 0` is mathematically impossible (always `False`), so out-of-range option values were never corrected to a random valid option. Fixed to `if not (0 <= option <= 2)`.
- `anomaly_check()`: The "new PGNs detected" message computed `baseline - after_fuzz` (showing *missing* PGNs) instead of `after_fuzz - baseline` (showing *new* PGNs). Swapped the operands to match the intent of the check on the line above.

## Test plan
- [x] All 170 existing tests pass
- [x] Both bugs are in fuzzing runtime paths that require a live CAN bus with real ECU traffic to exercise end-to-end