### PR TITLE
Fix method signatures and find_proprietary null crash

### DIFF
--- a/tests/test_module_ecu_discovery.py
+++ b/tests/test_module_ecu_discovery.py
@@ -238,17 +238,21 @@ def test_ecu_discovery_class_add_duplicate(truckdevil_module_env):
 
 
 def test_ecu_discovery_find_proprietary_smoke(truckdevil_module_env, shared_channel):
-    """find_proprietary: hits a bug in do_find_proprietary when no messages match --
-    e is None and the code tries e.prop_messages. This documents the existing bug."""
+    """find_proprietary with no matching messages prints a 'not found' message instead of crashing."""
     from libs.device import Device
     import modules.ecu_discovery as ecu_discovery
 
     device = Device("virtual", None, shared_channel, 250000)
     try:
         with patch("modules.ecu_discovery.time.sleep"):
-            # Known bug: AttributeError when no proprietary messages found for unknown ECU
-            with pytest.raises(AttributeError, match="prop_messages"):
+            buf = io.StringIO()
+            old = sys.stdout
+            try:
+                sys.stdout = buf
                 ecu_discovery.main_mod(["find_proprietary", "11", "back"], device)
+            finally:
+                sys.stdout = old
+            assert "no proprietary messages found" in buf.getvalue()
     finally:
         if device.can_bus is not None:
             try:

--- a/truckdevil/modules/ecu_discovery.py
+++ b/truckdevil/modules/ecu_discovery.py
@@ -226,6 +226,9 @@ class DiscoveryCommands(Command):
                     e = ECU(address)
                     self.ed.add_known_ecu(e)
                 e.add_prop_message(m)
+        if e is None:
+            print("no proprietary messages found for address {}.".format(address))
+            return
         discovered = len(e.prop_messages) - num_prop_messages
         if discovered > 0:
             print("discovered {} new unique proprietary messages.".format(discovered))
@@ -333,7 +336,6 @@ class DiscoveryCommands(Command):
         else:
             print(found_msg)
 
-    @staticmethod
     def do_back(self, arg=None):
         """
         Return to the main menu

--- a/truckdevil/modules/j1939_fuzzer.py
+++ b/truckdevil/modules/j1939_fuzzer.py
@@ -916,14 +916,12 @@ class FuzzerCommands(Command):
 
         return
 
-    @staticmethod
     def do_back(self, arg=None):
         """
         Return to the main menu
         """
         return True
 
-    @staticmethod
     def do_EOF(self, arg=None):
         """
         Following a ctrl-d quit the whole program


### PR DESCRIPTION
## Summary
- Removed incorrect `@staticmethod` decorator from `do_back` and `do_EOF` in `j1939_fuzzer.py` and `ecu_discovery.py`. These methods take `self` but were decorated as static methods, which only worked by accident because `cmd.Cmd` passes the args string as the first positional argument.
- Added a null guard in `do_find_proprietary` so that when no ECU is found at the given address and no proprietary messages match, a friendly message is printed instead of crashing with `AttributeError: 'NoneType' object has no attribute 'prop_messages'`.
- Updated `test_ecu_discovery_find_proprietary_smoke` to verify the new graceful output instead of asserting the previous crash.

## Test plan
- [x] All 170 existing tests pass
- [x] `test_ecu_discovery_find_proprietary_smoke` now verifies the fix directly