### PR TITLE
Fix save/import format mismatch for data logs

### DIFF
--- a/tests/test_j1939_integration.py
+++ b/tests/test_j1939_integration.py
@@ -378,19 +378,23 @@ def test_save_data_collected_writes_file(j1939_interface, tmp_path):
     assert "0CEC000B" in content
 
 
-def test_import_data_collected_known_limitation(j1939_interface, tmp_path):
-    """import_data_collected can't parse current __str__ format (has timestamp prefix).
-    This documents the known TODO in the source. The parser expects 8 parts but
-    __str__ now outputs 9 (timestamp + original fields).
-    """
-    messages = [J1939Message(0x18EA00FF, "AABBCCDDEEFF0011")]
-    messages[0].timestamp = 1.0
+def test_import_data_collected_roundtrip(j1939_interface, tmp_path):
+    """save_data_collected then import_data_collected round-trips CAN ID and data."""
+    messages = [
+        J1939Message(0x18EA00FF, "AABBCCDDEEFF0011"),
+        J1939Message(0x0CEC000B, "1122334455667788"),
+    ]
+    for m in messages:
+        m.timestamp = 1.0
     f = tmp_path / "test_log2.txt"
     j1939_interface.save_data_collected(messages, file_name=str(f))
 
     imported = j1939_interface.import_data_collected(str(f))
-    # Known bug: returns empty because __str__ format doesn't match the parser
-    assert imported == []
+    assert len(imported) == 2
+    assert imported[0].can_id == 0x18EA00FF
+    assert imported[0].data.upper() == "AABBCCDDEEFF0011"
+    assert imported[1].can_id == 0x0CEC000B
+    assert imported[1].data.upper() == "1122334455667788"
 
 
 def test_save_data_collected_empty_raises(j1939_interface, tmp_path):

--- a/truckdevil/j1939/j1939.py
+++ b/truckdevil/j1939/j1939.py
@@ -363,7 +363,6 @@ class J1939Interface:
         return data_collected
 
     def save_data_collected(self, messages, file_name=None, verbose=False, pretty=False):
-        # TODO: fix save/load functions
         """
         Save the collected messages to a log file
 
@@ -373,26 +372,25 @@ class J1939Interface:
         :param pretty: whether or not to save the message in pretty form (Default value = False).
                         Mutually exclusive with verbose; if both are True, pretty takes priority.
         """
-        # If given messages list is empty
         if len(messages) == 0:
             raise Exception('messages list is empty')
         if file_name is None:
             file_name = 'log_{}.txt'.format(str(int(time.time())))
-        f = open(file_name, "x")
-        f.write("""CAN_ID   Priority    PGN    Source --> Destination    [Num Bytes]    data""" + '\n')
-        for m in messages:
-            if pretty:
-                f.write("{}\n".format(self.pretty_shim.get_pretty_output(m)))
-            elif not verbose:
-                f.write("{}\n".format(m))
-            else:
-                f.write("{}\n".format(self.get_decoded_message(m)))
-        f.close()
+        with open(file_name, "x") as f:
+            f.write("Timestamp    CAN_ID    Priority    PGN    Source --> Destination    [Num Bytes]    data\n")
+            for m in messages:
+                if pretty:
+                    f.write("{}\n".format(self.pretty_shim.get_pretty_output(m)))
+                elif not verbose:
+                    f.write("{}\n".format(m))
+                else:
+                    f.write("{}\n".format(self.get_decoded_message(m)))
 
     def import_data_collected(self, file_name):
-        # TODO: fix save/load functions
         """
-        Converts log file to list of J1939Message objects
+        Converts log file to list of J1939Message objects.
+        Supports both the current format (with timestamp prefix) and the
+        legacy format (without timestamp).
 
         :param file_name: the name of the file where the data is saved
         :returns: list of J1939Message objects from log file
@@ -404,15 +402,21 @@ class J1939Interface:
                 for line in inFile:
                     if first_line:
                         first_line = False
-                    else:
-                        parts = line.split()
-                        if len(parts) == 8 and parts[4] == '-->' and '[' in line:
-                            message = J1939Message(
-                                can_id=int(parts[0], 16),
-                                data=parts[7]
-                            )
-                            messages.append(message)
-                return messages
+                        continue
+                    parts = line.split()
+                    if len(parts) == 9 and parts[5] == '-->' and '[' in line:
+                        message = J1939Message(
+                            can_id=int(parts[1], 16),
+                            data=parts[8]
+                        )
+                        messages.append(message)
+                    elif len(parts) == 8 and parts[4] == '-->' and '[' in line:
+                        message = J1939Message(
+                            can_id=int(parts[0], 16),
+                            data=parts[7]
+                        )
+                        messages.append(message)
+            return messages
         else:
             raise Exception('file name given does not exist.')
 


### PR DESCRIPTION
## Summary
- `import_data_collected` expected 8 whitespace-separated columns, but `J1939Message.__str__` now outputs 9 (timestamp prefix was added). Saved log files could not be re-imported.
- Updated the parser to handle the current 9-column format while retaining backward compatibility with the legacy 8-column format.
- `save_data_collected` now uses a `with` context manager for file operations (prevents file handle leaks on exceptions) and writes a header that matches the current output format.
- Removed the `# TODO: fix save/load functions` comments since this resolves them.
- Replaced `test_import_data_collected_known_limitation` (which asserted the bug) with `test_import_data_collected_roundtrip` (which verifies CAN ID and data survive a save/import cycle).

## Test plan
- [x] All 170 existing tests pass
- [x] New `test_import_data_collected_roundtrip` verifies save then import correctly round-trips CAN ID and data for multiple messages