### PR TITLE
Reorder backoff delay and send in libs/device.py

### DIFF
--- a/truckdevil/libs/device.py
+++ b/truckdevil/libs/device.py
@@ -145,8 +145,8 @@ class Device:
             sleeptime = 0.0
             while True:
                 try:
-                    self._can_bus.send(msg)
                     time.sleep(sleeptime)
+                    self._can_bus.send(msg)
                     return
                 except can.CanOperationError as e:
                     if sleeptime == 0.0:


### PR DESCRIPTION
When sending a message to the CAN bus, the `send` function repeatedly tries to send data on the device until it succeeds, incrementing the backoff time each attempt.
However, the call to sleep with the incremented backoff time is done after attempting to send the message on the bus.
This means that if the send is unsuccessful, the call to sleep will never actually be run making the backoff time useless.

I encountered this repeatedly where the send would fail due to the transmit buffer filling up, so the program would keep attempting to send on the full bus without any delay until the send is successful, which would then trigger the sleep with an incredibly long backoff time causing the tool to hang indefinitely.
<img width="588" height="545" alt="image (1)" src="https://github.com/user-attachments/assets/5b949129-f273-4fd3-b994-ae589e209c3f" />

Therefore, simply switching the order of the _can_bus.send() and time.sleep() will actually apply the delay before retying.